### PR TITLE
Use arguments instead of environment variables

### DIFF
--- a/stager/stager.go
+++ b/stager/stager.go
@@ -69,20 +69,18 @@ func (stager *stager) Stage(request StagingRequest, replyTo string) error {
 		buildpacksOrder = append(buildpacksOrder, buildpack.Key)
 	}
 
-	env := [][]string{
-		{"APP_DIR", "/app"},
-		{"OUTPUT_DIR", "/tmp/droplet"},
-		{"RESULT_DIR", "/tmp/result"},
-		{"BUILDPACKS_DIR", "/tmp/buildpacks"},
-		{"BUILDPACK_ORDER", strings.Join(buildpacksOrder, ",")},
-		{"CACHE_DIR", "/tmp/cache"},
-	}
-	env = append(request.Environment, env...)
+	script := "/tmp/compiler/run" +
+		" -appDir /app" +
+		" -outputDir /tmp/droplet" +
+		" -resultDir /tmp/result" +
+		" -buildpacksDir /tmp/buildpacks" +
+		" -buildpackOrder " + strings.Join(buildpacksOrder, ",") +
+		" -cacheDir /tmp/cache"
 
 	actions = append(actions, models.ExecutorAction{
 		models.RunAction{
-			Script:  "/tmp/compiler/run",
-			Env:     env,
+			Script:  script,
+			Env:     request.Environment,
 			Timeout: 15 * time.Minute,
 		},
 	})

--- a/stager/stager_test.go
+++ b/stager/stager_test.go
@@ -106,16 +106,16 @@ var _ = Describe("Stage", func() {
 				},
 				{
 					RunAction{
-						Script: "/tmp/compiler/run",
+						Script: "/tmp/compiler/run" +
+							" -appDir /app" +
+							" -outputDir /tmp/droplet" +
+							" -resultDir /tmp/result" +
+							" -buildpacksDir /tmp/buildpacks" +
+							" -buildpackOrder zfirst-buildpack,asecond-buildpack" +
+							" -cacheDir /tmp/cache",
 						Env: [][]string{
 							{"VCAP_APPLICATION", "foo"},
 							{"VCAP_SERVICES", "bar"},
-							{"APP_DIR", "/app"},
-							{"OUTPUT_DIR", "/tmp/droplet"},
-							{"RESULT_DIR", "/tmp/result"},
-							{"BUILDPACKS_DIR", "/tmp/buildpacks"},
-							{"BUILDPACK_ORDER", "zfirst-buildpack,asecond-buildpack"},
-							{"CACHE_DIR", "/tmp/cache"},
 						},
 						Timeout: 15 * time.Minute,
 					},


### PR DESCRIPTION
Prevent environment pollution by using command line arguments.
