### PR TITLE
do not return detected_start_command for buildpack lifecycle

### DIFF
--- a/backend/buildpack_backend.go
+++ b/backend/buildpack_backend.go
@@ -271,7 +271,6 @@ func (backend *traditionalBackend) BuildStagingResponse(taskResponse *models.Tas
 		lifecycleData := json.RawMessage(lifecycleDataJSON)
 
 		response.ExecutionMetadata = result.ExecutionMetadata
-		response.DetectedStartCommand = result.DetectedStartCommand
 		response.LifecycleData = &lifecycleData
 	}
 

--- a/backend/buildpack_backend_test.go
+++ b/backend/buildpack_backend_test.go
@@ -620,7 +620,6 @@ var _ = Describe("TraditionalBackend", func() {
 								BuildpackKey:         "buildpack-key",
 								DetectedBuildpack:    "detected-buildpack",
 								ExecutionMetadata:    "metadata",
-								DetectedStartCommand: map[string]string{"a": "b"},
 							}
 							var err error
 							stagingResultJson, err = json.Marshal(stagingResult)
@@ -640,7 +639,6 @@ var _ = Describe("TraditionalBackend", func() {
 							Expect(buildError).NotTo(HaveOccurred())
 							Expect(response).To(Equal(cc_messages.StagingResponseForCC{
 								ExecutionMetadata:    "metadata",
-								DetectedStartCommand: map[string]string{"a": "b"},
 								LifecycleData:        &responseLifecycleData,
 							}))
 

--- a/cmd/stager/main_test.go
+++ b/cmd/stager/main_test.go
@@ -249,7 +249,6 @@ var _ = Describe("Stager", func() {
 							ghttp.VerifyContentType("application/json"),
 							ghttp.VerifyJSON(`{
 								"execution_metadata": "metadata",
-								"detected_start_command": {"a": "b"},
 								"lifecycle_data": {
 									"buildpack_key": "buildpack-key",
 									"detected_buildpack": "detected-buildpack"
@@ -266,8 +265,7 @@ var _ = Describe("Stager", func() {
 						Result: `{
 							"buildpack_key": "buildpack-key",
 							"detected_buildpack": "detected-buildpack",
-							"execution_metadata": "metadata",
-							"detected_start_command": {"a": "b"}
+							"execution_metadata": "metadata"
 						}`,
 					})
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- all necessary info now comes from execution_metadata

[#103337820]

Signed-off-by: Jonathan Berkhahn jaberkha@us.ibm.com
