### PR TITLE
Loosen requirements to match 'insufficient resources' error message

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -80,7 +80,7 @@ func SanitizeErrorMessage(message string) *cc_messages.StagingError {
 	case strings.HasSuffix(message, strconv.Itoa(buildpackapplifecycle.RELEASE_FAIL_CODE)):
 		id = cc_messages.BUILDPACK_RELEASE_FAILED
 		message = staging_failed
-	case message == diego_errors.INSUFFICIENT_RESOURCES_MESSAGE:
+	case strings.HasPrefix(message, diego_errors.INSUFFICIENT_RESOURCES_MESSAGE):
 		id = cc_messages.INSUFFICIENT_RESOURCES
 	case message == diego_errors.CELL_MISMATCH_MESSAGE:
 		id = cc_messages.NO_COMPATIBLE_CELL

--- a/backend/buildpack_backend_test.go
+++ b/backend/buildpack_backend_test.go
@@ -615,10 +615,16 @@ var _ = Describe("TraditionalBackend", func() {
 
 	Describe("SanitizeErrorMessage", func() {
 		Context("when the message is InsufficientResources", func() {
-			It("returns a InsufficientResources", func() {
-				stagingErr := backend.SanitizeErrorMessage(diego_errors.INSUFFICIENT_RESOURCES_MESSAGE)
+			It("returns an InsufficientResources memory error", func() {
+				stagingErr := backend.SanitizeErrorMessage("insufficient resources: memory")
 				Expect(stagingErr.Id).To(Equal(cc_messages.INSUFFICIENT_RESOURCES))
-				Expect(stagingErr.Message).To(Equal(diego_errors.INSUFFICIENT_RESOURCES_MESSAGE))
+				Expect(stagingErr.Message).To(Equal("insufficient resources: memory"))
+			})
+
+			It("returns an InsufficientResources disk error", func() {
+				stagingErr := backend.SanitizeErrorMessage("insufficient resources: disk")
+				Expect(stagingErr.Id).To(Equal(cc_messages.INSUFFICIENT_RESOURCES))
+				Expect(stagingErr.Message).To(Equal("insufficient resources: disk"))
 			})
 		})
 


### PR DESCRIPTION
Soon, Diego will be returning more detail in the case of insufficient
resources. This change makes it so that the stager recognizes any Diego
error message starting with 'insufficient resources', not only exact
matches.

[#126961241]

Signed-off-by: Anoop Gopalakrishnan agopalakrishnan@pivotal.io
