### PR TITLE
Support new NO_COMPATIBLE_CELL errors from Diego

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -82,7 +82,7 @@ func SanitizeErrorMessage(message string) *cc_messages.StagingError {
 		message = staging_failed
 	case strings.HasPrefix(message, diego_errors.INSUFFICIENT_RESOURCES_MESSAGE):
 		id = cc_messages.INSUFFICIENT_RESOURCES
-	case message == diego_errors.CELL_MISMATCH_MESSAGE:
+	case strings.HasPrefix(message, diego_errors.CELL_MISMATCH_MESSAGE):
 		id = cc_messages.NO_COMPATIBLE_CELL
 	case message == diego_errors.CELL_COMMUNICATION_ERROR:
 		id = cc_messages.CELL_COMMUNICATION_ERROR

--- a/backend/buildpack_backend_test.go
+++ b/backend/buildpack_backend_test.go
@@ -636,6 +636,22 @@ var _ = Describe("TraditionalBackend", func() {
 			})
 		})
 
+		Context("when the message is NoCompatibleCell Volume Drivers", func() {
+			It("returns a NoCompatibleCell", func() {
+				stagingErr := backend.SanitizeErrorMessage("found no compatible cell with volume drivers: [driver1]")
+				Expect(stagingErr.Id).To(Equal(cc_messages.NO_COMPATIBLE_CELL))
+				Expect(stagingErr.Message).To(ContainSubstring(diego_errors.CELL_MISMATCH_MESSAGE))
+			})
+		})
+
+		Context("when the message is NoCompatibleCell Placement tags", func() {
+			It("returns a NoCompatibleCell", func() {
+				stagingErr := backend.SanitizeErrorMessage("found no compatible cell with placement tags: [tag1, tag2]")
+				Expect(stagingErr.Id).To(Equal(cc_messages.NO_COMPATIBLE_CELL))
+				Expect(stagingErr.Message).To(ContainSubstring(diego_errors.CELL_MISMATCH_MESSAGE))
+			})
+		})
+
 		Context("when the message is CellCommunicationError", func() {
 			It("returns a CellCommunicationError", func() {
 				stagingErr := backend.SanitizeErrorMessage(diego_errors.CELL_COMMUNICATION_ERROR)


### PR DESCRIPTION
Diego Team added more specific information on why no compatible cells are found

Could be due to placement tag mismatch or volume driver mismatch etc.

[#129370089]

Signed-off-by: Andrew Edgar aedgar@ca.ibm.com
