### PR TITLE
Make consulTTL value configurable

### DIFF
--- a/cmd/stager/main.go
+++ b/cmd/stager/main.go
@@ -108,6 +108,12 @@ var consulCluster = flag.String(
 	"Consul Agent URL",
 )
 
+var consulTTL = flag.String(
+	"consulTTL",
+	"3",
+	"TTL value for consul registration in seconds",
+)
+
 var dockerStagingStack = flag.String(
 	"dockerStagingStack",
 	"",
@@ -286,7 +292,7 @@ func initializeRegistrationRunner(logger lager.Logger, consulClient consuladapte
 		Name: "stager",
 		Port: port,
 		Check: &api.AgentServiceCheck{
-			TTL: "3s",
+			TTL: *consulTTL + "s",
 		},
 	}
 	return locket.NewRegistrationRunner(logger, registration, consulClient, locket.RetryInterval, clock)


### PR DESCRIPTION
- The default TTL value of 3 seconds results in a poll interval for 1.5 seconds for consul healthchecks.
  with all the diego components behaving this way, the consul in PCF Dev gets overloaded and goes unresponsive.
  PCF Dev needs this value to be increased/configurable.

This became necessary when these services switch from using `dns_health_check` to the TTL method. When the `dns_health_check` does not succeed within the TTL, consul will still respond to DNS queries for that service. Using the new TTL method, consul will unregister the service from it's DNS registry if it fails to update it's healthcheck status within the TTL.

Signed-off-by: Mark DeLillo mdelillo@pivotal.io
