### PR TITLE
Integrate CC and diego for IS

### DIFF
--- a/backend/buildpack_backend.go
+++ b/backend/buildpack_backend.go
@@ -213,6 +213,10 @@ func (backend *traditionalBackend) BuildRecipe(stagingGuid string, request cc_me
 		TrustedSystemCertificatesPath: TrustedSystemCertificatesPath,
 	}
 
+	if request.IsolationSegment != "" {
+		taskDefinition.PlacementTags = []string{request.IsolationSegment}
+	}
+
 	logger.Debug("staging-task-request")
 
 	return taskDefinition, stagingGuid, backend.config.TaskDomain, nil

--- a/backend/buildpack_backend_test.go
+++ b/backend/buildpack_backend_test.go
@@ -244,6 +244,7 @@ var _ = Describe("TraditionalBackend", func() {
 		Expect(taskDef.LogSource).To(Equal(backend.TaskLogSource))
 		Expect(taskDef.ResultFile).To(Equal("/tmp/result.json"))
 		Expect(taskDef.Privileged).To(BeFalse())
+		Expect(taskDef.PlacementTags).To(BeEmpty())
 
 		var annotation cc_messages.StagingTaskAnnotation
 		err = json.Unmarshal([]byte(taskDef.Annotation), &annotation)
@@ -281,6 +282,18 @@ var _ = Describe("TraditionalBackend", func() {
 		Expect(taskDef.CpuWeight).To(Equal(backend.StagingTaskCpuWeight))
 		Expect(taskDef.EgressRules).To(ConsistOf(egressRules))
 		Expect(taskDef.LegacyDownloadUser).To(Equal("vcap"))
+	})
+
+	Context("with a specified isolation segment", func() {
+		JustBeforeEach(func() {
+			stagingRequest.IsolationSegment = "foo"
+		})
+
+		It("includes the correct isolation segment in the placement tags", func() {
+			taskDef, _, _, err := traditional.BuildRecipe(stagingGuid, stagingRequest)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(taskDef.PlacementTags).To(ContainElement("foo"))
+		})
 	})
 
 	Context("with a specified buildpack", func() {


### PR DESCRIPTION
Signed-off-by: Dan Lavine <dlavine@us.ibm.com>

Enable the passing of Isolation Segment labels as part of staging for Diego.

This PR depends on [this PR to runtimeschema](https://github.com/cloudfoundry/runtimeschema/pull/13).